### PR TITLE
Set group id to org.gwtproject.dom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java-library'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
-group = 'org.gwtproject'
+group = 'org.gwtproject.dom'
 version = '1.0-SNAPSHOT'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'java-library'
+plugins {
+ id 'java-library'
+ id 'maven'
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 group = 'org.gwtproject.dom'


### PR DESCRIPTION
Per request from @FrankHossfeld, adding the `.dom` suffix to group seems to make good sense to me.

The addition of the maven plugin is a bit of a shot in the dark, but once this merges and deploys to CI, we can check for the presence of a pom + maven metadata, and if missing, try something more drastic (i.e. actually adding and properly configuring artifactory plugin)