### PR TITLE
Use standard jsinterop-base, to retain GWT 2.8.2 compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ repositories {
 
 dependencies {
     api 'com.google.elemental2:elemental2-dom:1.0.0-RC1'
-    api 'org.realityforge.com.google.jsinterop:base:1.0.0-b2-e6d791f'
     api 'org.gwtproject.core:gwt-core:1.0-SNAPSHOT'
     api 'org.gwtproject.safehtml:gwt-safehtml:1.0-SNAPSHOT'
     api 'org.gwtproject.safecss:gwt-safecss:1.0-SNAPSHOT'
@@ -30,9 +29,6 @@ dependencies {
     testImplementation 'com.google.gwt:gwt-user:2.8.2'
     testImplementation 'com.vertispan.j2cl:junit-annotations:0.3-SNAPSHOT'
     testRuntimeOnly 'com.google.gwt:gwt-dev:2.8.2'
-}
-configurations {
-    compile.exclude group:'com.google.jsinterop', module:'base'
 }
 
 jar {


### PR DESCRIPTION
This avoids classpath issues when dependencies bring their own,
slightly-incompatible versions of jsinterop-base.

This workaround used to be needed when we were iterating to fix the $doc issue, but no longer is, and is causing problems downstream.